### PR TITLE
fix:Setting Shadow DOM to none for fa-icon component

### DIFF
--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -39,7 +39,8 @@ import { FaIconService } from './icon.service';
   template: ``,
   host: {
     class: 'ng-fa-icon',
-  }
+  },
+  encapsulation: ViewEncapsulation.None
 })
 export class FaIconComponent implements OnChanges {
   // tslint:disable-next-line:no-input-rename


### PR DESCRIPTION
Without View Encapsulation set to none,  it's impossible to have styles applied to the SVG element without [ng-deep](https://angular.io/guide/component-styles#deprecated-deep--and-ng-deep)(which is deprecated and will soon not work).

[Documentation on  Angular's View Encapsulation](https://angular.io/api/core/ViewEncapsulation) 